### PR TITLE
Update set-output calls in GHA

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)


### PR DESCRIPTION
# **JIRA Task:** [Q1 2023 :: Github Actions deprecating `set-output`](https://rewind.atlassian.net/browse/DEVOPS-705)

## Description of change

`set-output` is set to be deprecated in 2023. This change migrates calls of set-output to use the GITHUB_OUTPUT env file instead as per GH's recommendation.
