### PR TITLE
Upate rubygems version in Ruby setup

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          rubygems: 3.4.3
 
       - name: Bundle install
         run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          rubygems: 3.4.3
+          rubygems: latest
 
       - name: Bundle install
         run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -49,10 +49,12 @@ jobs:
             os: ubuntu-latest
             gemfile: gemfiles/Gemfile-rails-edge
             experimental: true
+            rubygems: latest
           - ruby: 3.0
             os: ubuntu-latest
             gemfile: gemfiles/Gemfile-rails-edge
             experimental: true
+            rubygems: latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,10 +26,6 @@ jobs:
           "gemfiles/Gemfile-rails.6.0.x",
           "gemfiles/Gemfile-rails.6.1.x"
         ]
-        rubygems: [
-          "default",
-          "latest"
-        ]
         exclude:
           - ruby: 2.4
             gemfile: gemfiles/Gemfile-rails.6.0.x
@@ -39,16 +35,6 @@ jobs:
             gemfile: gemfiles/Gemfile-rails.6.1.x
           - ruby: 3.0
             gemfile: gemfiles/Gemfile-rails.5.2.x
-          - ruby: 2.4
-            rubygems: latest
-          - ruby: 2.5
-            rubygems: latest
-          - ruby: 2.6
-            rubygems: default
-          - ruby: 2.7
-            rubygems: default
-          - ruby: 3.0
-            rubygems: default
         experimental: [false]
         include:
           - ruby: 2.7
@@ -59,6 +45,10 @@ jobs:
             os: ubuntu-latest
             gemfile: gemfiles/Gemfile-rails-edge
             experimental: true
+          - ruby: 2.7
+            rubygems: latest
+          - ruby: 3.0
+            rubygems: latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,13 +26,20 @@ jobs:
           "gemfiles/Gemfile-rails.6.0.x",
           "gemfiles/Gemfile-rails.6.1.x"
         ]
+        rubygems: [
+          "default",
+          "latest"
+        ]
         exclude:
           - ruby: 2.4
             gemfile: gemfiles/Gemfile-rails.6.0.x
+            rubygems: latest
           - ruby: 2.4
             gemfile: gemfiles/Gemfile-rails.6.1.x
+            rubygems: latest
           - ruby: 2.5
             gemfile: gemfiles/Gemfile-rails.6.1.x
+            rubygems: latest
           - ruby: 3.0
             gemfile: gemfiles/Gemfile-rails.5.2.x
         experimental: [false]
@@ -61,7 +68,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          rubygems: latest
+          rubygems: ${{ matrix.rubygems }}
 
       - name: Bundle install
         run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,12 +33,13 @@ jobs:
         exclude:
           - ruby: 2.4
             gemfile: gemfiles/Gemfile-rails.6.0.x
-            rubygems: latest
           - ruby: 2.4
             gemfile: gemfiles/Gemfile-rails.6.1.x
+          - ruby: 2.4
             rubygems: latest
           - ruby: 2.5
             gemfile: gemfiles/Gemfile-rails.6.1.x
+          - ruby: 2.5
             rubygems: latest
           - ruby: 3.0
             gemfile: gemfiles/Gemfile-rails.5.2.x

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,14 +41,11 @@ jobs:
             os: ubuntu-latest
             gemfile: gemfiles/Gemfile-rails-edge
             experimental: true
+            rubygems: latest
           - ruby: 3.0
             os: ubuntu-latest
             gemfile: gemfiles/Gemfile-rails-edge
             experimental: true
-          - ruby: 2.7
-            rubygems: latest
-          - ruby: 3.0
-            rubygems: latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,26 +35,30 @@ jobs:
             gemfile: gemfiles/Gemfile-rails.6.0.x
           - ruby: 2.4
             gemfile: gemfiles/Gemfile-rails.6.1.x
+          - ruby: 2.5
+            gemfile: gemfiles/Gemfile-rails.6.1.x
+          - ruby: 3.0
+            gemfile: gemfiles/Gemfile-rails.5.2.x
           - ruby: 2.4
             rubygems: latest
           - ruby: 2.5
-            gemfile: gemfiles/Gemfile-rails.6.1.x
-          - ruby: 2.5
             rubygems: latest
+          - ruby: 2.6
+            rubygems: default
+          - ruby: 2.7
+            rubygems: default
           - ruby: 3.0
-            gemfile: gemfiles/Gemfile-rails.5.2.x
+            rubygems: default
         experimental: [false]
         include:
           - ruby: 2.7
             os: ubuntu-latest
             gemfile: gemfiles/Gemfile-rails-edge
             experimental: true
-            rubygems: latest
           - ruby: 3.0
             os: ubuntu-latest
             gemfile: gemfiles/Gemfile-rails-edge
             experimental: true
-            rubygems: latest
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I noticed a couple of matrix workflows were failing when I was updating workflows to support Node 16.

This PR uses the latest version of the rubygems gem depending on the needs of the Ruby version and Rails version. In this case, we specify the latest version for the 2.7 version of Ruby with the edge version of Rails.